### PR TITLE
ImageService updates

### DIFF
--- a/src/Fanzoo.Kernel/Services/Abstractions/IImageService.cs
+++ b/src/Fanzoo.Kernel/Services/Abstractions/IImageService.cs
@@ -35,5 +35,9 @@
         Stream OverlayCenteredImage(Stream backgroundImage, Stream overlayImage, ImageFormat imageFormat = ImageFormat.Png, int quality = 100);
 
         byte[] OverlayCenteredImage(byte[] backgroundImage, byte[] overlayImage, ImageFormat imageFormat = ImageFormat.Png, int quality = 100);
+
+        Stream ConvertImage(Stream image, ImageFormat imageFormat, int quality = 100);
+
+        byte[] ConvertImage(byte[] image, ImageFormat imageFormat, int quality = 100);
     }
 }

--- a/src/Fanzoo.Kernel/Services/SkiaImageService.cs
+++ b/src/Fanzoo.Kernel/Services/SkiaImageService.cs
@@ -97,6 +97,22 @@ namespace Fanzoo.Kernel.Services
             return outputImageStream.ReadAllBytes();
         }
 
+        public Stream ConvertImage(Stream image, ImageFormat imageFormat, int quality = 100)
+        {
+            var originalImage = SKBitmap.Decode(image);
+
+            return originalImage.Encode(imageFormat.ToSKEncodedImageFormat(), quality).AsStream();
+        }
+
+        public byte[] ConvertImage(byte[] image, ImageFormat imageFormat, int quality = 100)
+        {
+            var imageStream = new MemoryStream(image);
+
+            var outputImageStream = ConvertImage(imageStream, imageFormat, quality);
+
+            return outputImageStream.ReadAllBytes();
+        }
+
         private static Stream OverlayImage(SKBitmap backgroundBmp, SKBitmap overlayBmp, int x, int y, ImageFormat imageFormat = ImageFormat.Png, int quality = 100)
         {
             var backgroundInfo = new SKImageInfo(backgroundBmp.Width, backgroundBmp.Height);


### PR DESCRIPTION
1. Addition of `ConvertImage(Stream image, ImageFormat imageFormat, int quality = 100)` method to `IImageService` interface and `SkiaImageService.cs`. This method takes an image as a stream, the desired image format, and the image quality as parameters. It then decodes the image into a `SKBitmap` object, encodes it into the desired format with the specified quality, and returns it as a stream.

2. Addition of `ConvertImage(byte[] image, ImageFormat imageFormat, int quality = 100)` method to `IImageService` interface and `SkiaImageService.cs`. This method takes an image as a byte array, the desired image format, and the image quality as parameters. It converts the byte array into a stream, calls the `ConvertImage(Stream image, ImageFormat imageFormat, int quality = 100)` method to convert the image, and returns the converted image as a byte array.